### PR TITLE
Describe JSON-document framing on transport layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ processed and send at any time. This allows to minimize message framing overhead
 
 # Messages
 
-This chapter lists an overview of all __active__ messsages by example.
+Messages are JSON-documents which are passed from the sender to the receiver using an underlaying transport mechanism. Depending on the nature of this mechanism additional [document-framing](transportlayer-binding.md) might be needed.
+
+The following chapter lists an overview of all __active__ messsages by example.
 
 ## add
 

--- a/transportlayer-binding.md
+++ b/transportlayer-binding.md
@@ -25,6 +25,7 @@ The sender prefixes each JSON document (aka message) with the length of the mess
 
 Remarks:
 * The length might include whitespace in the JSON document, including heading (before the first '''{''') and trailing (following after the last '''}'''
+* Theoretically, an additional framing is not necessary since the JSON-format is capable of determining if a JSON document is complete. In the real world, JSON-parsers which create object tree-structures in memory are popular. These parsers are not able to work on a stream of incoming characters and need the entire, complete JSON-document as an input string. The lenght-prefixed document framing eases the preprocessing step for these parsers.
 
 # Transport Layers and Jet Message Framing
 

--- a/transportlayer-binding.md
+++ b/transportlayer-binding.md
@@ -1,0 +1,36 @@
+# Summary
+
+As described elsewhere Jet messages are encoded as JSON documents.
+These documents need to be passed from sender to receiver using the underlying transport layer.
+
+Jet by itself is independent from the transport layer.
+Nevertheless, on stream-oriented connections, there is the necessity to separate an incoming stream of characters
+into the distinct JSON documents it is composed from.
+Some transport layers are able to transfer the document framing inherently, while others are not.
+
+# Document Framing Implementation
+
+In case the transport layer is solely stream oriented a document framing is introduced at the "transport layer binding" level.
+
+This is always done according to the following definition:
+
+## length-prefixed
+
+The sender prefixes each JSON document (aka message) with the length of the message.
+
+* The length is allway encoded in four octets (aka bytes)
+* The four octets encode an unsigned integer, in binary encoding
+* The order of the four octets is network-byte-order
+* The number encoded is the length of the JSON document, not including the four length octets.
+
+Remarks:
+* The length might include whitespace in the JSON document, including heading (before the first '''{''') and trailing (following after the last '''}'''
+
+# Transport Layers and Jet Message Framing
+
+| Transport | Document Framing     |
+| --------- | -------------------- |
+| TCP       | length-prefixed      |
+| WebSocket | no framing, since the WebSocket-protocol is document-oriented |
+| RS-232    | length-prefixed |
+


### PR DESCRIPTION
On raw TCP (or RS-232) connections Jet-messages use a "streaming" connection. The receiver needs to split the stream of characters into the documents. Here is the specification on how this is achieved.
